### PR TITLE
feat(git) Add alias gswr => git switch --recurse-submodule

### DIFF
--- a/plugins/git/git.plugin.zsh
+++ b/plugins/git/git.plugin.zsh
@@ -287,6 +287,7 @@ alias gstall='git stash --all'
 alias gsu='git submodule update'
 alias gsw='git switch'
 alias gswc='git switch -c'
+alias gswr='git switch --recurse-submodules'
 
 alias gts='git tag -s'
 alias gtv='git tag | sort -V'


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- added an alias alias gswr='git switch --recurse-submodules'  as git checkout --recurse-submodules already has an alias, this would help to switch branches containing submodules without having to use git checkout or deinit/init


